### PR TITLE
Add BigInt support

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,17 @@ var id = hashids.encodeHex('507f1f77bcf86cd799439011'); // y42LW46J9luq3Xq9XMly
 var hex = hashids.decodeHex(id); // 507f1f77bcf86cd799439011
 ```
 
+**Encode bigint numbers:**
+
+Useful if you want to encode [PostgreSQL](https://www.postgresql.org/)'s bigint. Note that currently pg javascript driver handles bigint as string since it's support is a current draft.
+
+```javascript
+var hashids = new Hashids();
+
+var id = hashids.encodeBI('50374626472636434472463271'); // ww2Vn9oypBtv1PZ2Rpp
+var hex = hashids.decodeBI(id); // 50374626472636434472463271
+```
+
 Pitfalls
 -------
 

--- a/lib/hashids.js
+++ b/lib/hashids.js
@@ -1,3 +1,4 @@
+const bigInt = require('big-integer');
 
 export default class Hashids {
 
@@ -161,6 +162,26 @@ export default class Hashids {
 		return ret;
 
 	}
+
+  encodeBI(id) {
+    // bigInt throws an exception on wrong input
+    const bi = bigInt(id, 10);
+    return this.encodeHex(bi.toString(16));
+  }
+
+  decodeBI(oid) {
+		let ret = null;
+
+    if (typeof oid === 'string' && oid.length) {
+      const hex = this.decodeHex(oid);
+      if (typeof hex === 'string' && hex.length) {
+        const bi = bigInt(hex, 16);
+        ret = bi.toString(10);
+      }
+    }
+    if (ret === null) throw new Error('Invalid id provided');
+		return ret;
+  }
 
 	_encode(numbers) {
 

--- a/lib/hashids.js
+++ b/lib/hashids.js
@@ -163,25 +163,29 @@ export default class Hashids {
 
 	}
 
-  encodeBI(id) {
-    // bigInt throws an exception on wrong input
-    const bi = bigInt(id, 10);
-    return this.encodeHex(bi.toString(16));
-  }
+	encodeBI(id) {
+		// bigInt throws an exception on wrong input
+		const bi = bigInt(id, 10);
+		return this.encodeHex(bi.toString(16));
+	}
 
-  decodeBI(oid) {
+	decodeBI(oid) {
 		let ret = null;
 
-    if (typeof oid === 'string' && oid.length) {
-      const hex = this.decodeHex(oid);
-      if (typeof hex === 'string' && hex.length) {
-        const bi = bigInt(hex, 16);
-        ret = bi.toString(10);
-      }
-    }
-    if (ret === null) throw new Error('Invalid id provided');
+		if (typeof oid === 'string' && oid.length) {
+			const hex = this.decodeHex(oid);
+			if (typeof hex === 'string' && hex.length) {
+				const bi = bigInt(hex, 16);
+				ret = bi.toString(10);
+			}
+		}
+
+		if (ret === null) {
+			throw new Error('Invalid id provided');
+		}
+
 		return ret;
-  }
+	}
 
 	_encode(numbers) {
 

--- a/lib/hashids.js
+++ b/lib/hashids.js
@@ -1,4 +1,3 @@
-const bigInt = require('big-integer');
 
 export default class Hashids {
 
@@ -164,27 +163,28 @@ export default class Hashids {
 	}
 
 	encodeBI(id) {
-		// bigInt throws an exception on wrong input
-		const bi = bigInt(id, 10);
-		return this.encodeHex(bi.toString(16));
-	}
 
-	decodeBI(oid) {
-		let ret = null;
-
-		if (typeof oid === 'string' && oid.length) {
-			const hex = this.decodeHex(oid);
-			if (typeof hex === 'string' && hex.length) {
-				const bi = bigInt(hex, 16);
-				ret = bi.toString(10);
-			}
+		if (!/^[0-9]+$/.test(id)) {
+			return '';
 		}
 
-		if (ret === null) {
-			throw new Error('Invalid id provided');
+		const bi = require('big-integer')(id, 10);
+		return this.encodeHex(bi.toString(16));
+
+	}
+
+	decodeBI(id) {
+
+		let ret = [];
+
+		const hex = this.decodeHex(id);
+		if (typeof hex === 'string' && hex.length) {
+			const bi = require('big-integer')(hex, 16);
+			ret = bi.toString(10);
 		}
 
 		return ret;
+
 	}
 
 	_encode(numbers) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -327,8 +327,7 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -338,8 +337,7 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -456,8 +454,7 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "ini": {
               "version": "1.3.5",
@@ -469,7 +466,6 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -595,8 +591,7 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true,
-              "optional": true
+              "dev": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -729,7 +724,6 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
-              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4314,7 +4308,8 @@
     "big-integer": {
       "version": "1.6.38",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.38.tgz",
-      "integrity": "sha512-csPPkI8MBCIoFAs2D7RoX9Bn5jrHwvQ/6CMfdRzwkB5cmpw74zb6Lbc/VbT9xCWrkgdwJDxw/uLIvXGch74Lhg=="
+      "integrity": "sha512-csPPkI8MBCIoFAs2D7RoX9Bn5jrHwvQ/6CMfdRzwkB5cmpw74zb6Lbc/VbT9xCWrkgdwJDxw/uLIvXGch74Lhg==",
+      "optional": true
     },
     "binary-extensions": {
       "version": "1.10.0",
@@ -4340,14 +4335,13 @@
       "dev": true
     },
     "browserslist": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.1.0.tgz",
-      "integrity": "sha512-kQBKB8hnq1SRfSpwHDpM1JNHAyk9fydW8hIDvndR2ijTFKIlBPEvkJkCt8JznOugdm12/YCaRgyq/sqDGz9PwA==",
-      "dev": true,
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.3.5.tgz",
+      "integrity": "sha512-z9ZhGc3d9e/sJ9dIx5NFXkKoaiQTnrvrMsN3R1fGb1tkWWNSz12UewJn9TNxGo1l7J23h0MRaPmk7jfeTZYs1w==",
       "requires": {
-        "caniuse-lite": "^1.0.30000878",
-        "electron-to-chromium": "^1.3.61",
-        "node-releases": "^1.0.0-alpha.11"
+        "caniuse-lite": "^1.0.30000912",
+        "electron-to-chromium": "^1.3.86",
+        "node-releases": "^1.0.5"
       }
     },
     "buffer-from": {
@@ -4397,10 +4391,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000883",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000883.tgz",
-      "integrity": "sha512-ovvb0uya4cKJct8Rj9Olstz0LaWmyJhCp3NawRG5fVigka8pEhIIwipF7zyYd2Q58UZb5YfIt52pVF444uj2kQ==",
-      "dev": true
+      "version": "1.0.30000913",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000913.tgz",
+      "integrity": "sha512-PP7Ypc35XY1mNduHqweGNOp0qfNUCmaQauGOYDByvirlFjrzRyY72pBRx7jnBidOB8zclg00DAzsy2H475BouQ=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -4766,10 +4759,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.62",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.62.tgz",
-      "integrity": "sha512-x09ndL/Gjnuk3unlAyoGyUg3wbs4w/bXurgL7wL913vXHAOWmMhrLf1VNGRaMLngmadd5Q8gsV9BFuIr6rP+Xg==",
-      "dev": true
+      "version": "1.3.87",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.87.tgz",
+      "integrity": "sha512-EV5FZ68Hu+n9fHVhOc9AcG3Lvf+E1YqR36ulJUpwaQTkf4LwdvBqmGIazaIrt4kt6J8Gw3Kv7r9F+PQjAkjWeA=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -5994,10 +5986,9 @@
       "dev": true
     },
     "node-releases": {
-      "version": "1.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
-      "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
-      "dev": true,
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.5.tgz",
+      "integrity": "sha512-Ky7q0BO1BBkG/rQz6PkEZ59rwo+aSfhczHP1wwq8IowoVdN/FpiP7qp0XW0P2+BVCWe5fQUBozdbVd54q1RbCQ==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -7636,8 +7627,7 @@
     "semver": {
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
-      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
-      "dev": true
+      "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw=="
     },
     "set-immediate-shim": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hashids",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -327,7 +327,8 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
@@ -337,7 +338,8 @@
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -454,7 +456,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -466,6 +469,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -591,7 +595,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -724,6 +729,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4304,6 +4310,11 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
+    },
+    "big-integer": {
+      "version": "1.6.38",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.38.tgz",
+      "integrity": "sha512-csPPkI8MBCIoFAs2D7RoX9Bn5jrHwvQ/6CMfdRzwkB5cmpw74zb6Lbc/VbT9xCWrkgdwJDxw/uLIvXGch74Lhg=="
     },
     "binary-extensions": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,7 @@
     "maintained node versions",
     "not dead"
   ],
-  "dependencies": {
-    "big-integer": "^1.6.38"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
@@ -65,5 +63,8 @@
     "decode",
     "encrypt",
     "decrypt"
-  ]
+  ],
+  "optionalDependencies": {
+    "big-integer": "^1.6.38"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,9 @@
     "maintained node versions",
     "not dead"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "big-integer": "^1.6.38"
+  },
   "devDependencies": {
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",

--- a/tests/bad-input.js
+++ b/tests/bad-input.js
@@ -88,4 +88,16 @@ describe('bad input', () => {
 		assert.deepEqual(numbers, []);
 	});
 
+	it(`should throw an error when encoding non-integer input`, () => {
+		assert.throws(() => {
+			hashids.encodeBI('z');
+		});
+	});
+
+	it(`should throw an error when decoding invalid BI id`, () => {
+		assert.throws(() => {
+			hashids.decodeBI('f');
+		});
+	});
+
 });

--- a/tests/bad-input.js
+++ b/tests/bad-input.js
@@ -88,16 +88,14 @@ describe('bad input', () => {
 		assert.deepEqual(numbers, []);
 	});
 
-	it(`should throw an error when encoding non-integer input`, () => {
-		assert.throws(() => {
-			hashids.encodeBI('z');
-		});
+	it(`should return an empty string when encoding non-integer input`, () => {
+		const id = hashids.encodeBI('z');
+		assert.equal(id, '');
 	});
 
-	it(`should throw an error when decoding invalid BI id`, () => {
-		assert.throws(() => {
-			hashids.decodeBI('f');
-		});
+	it(`should return an empty array when decoding invalid BI id`, () => {
+		const numbers = hashids.decodeBI('f');
+		assert.deepEqual(numbers, []);
 	});
 
 });

--- a/tests/custom-params-bi.js
+++ b/tests/custom-params-bi.js
@@ -1,0 +1,44 @@
+
+import Hashids from '../lib/hashids';
+import { assert } from 'chai';
+
+const minLength = 30;
+const hashids = new Hashids('this is my salt', minLength, 'xzal86grmb4jhysfoqp3we7291kuct5iv0nd');
+
+const map = {
+	'0dbq3jwa8p4b3gk6gb8bv21goerm96': '3735928559',
+	'190obdnk4j02pajjdande7aqj628mr': '188900967593046',
+	'a1nvl5d9m3yo8pj1fqag8p9pqw4dyl': '12981155274522450858012398',
+	'1nvlml93k3066oas3l9lr1wn1k67dy': '24912482966938930280208240657',
+	'mgyband33ye3c6jj16yq1jayh6krqjbo': '19938421193860583634706025513334057899',
+	'9mnwgllqg1q2tdo63yya35a9ukgl6bbn6qn8': '14966276559563682702364767401166784150254678',
+	'edjrkn9m6o69s0ewnq5lqanqsmk6loayorlohwd963r53e63xmml29': '6170642089954522658081134434590064393685259496125924487557283855',
+	'grekpy53r2pjxwyjkl9aw0k3t5la1b8d5r1ex9bgeqmy93eata0eq0': '6582018229284824168619876730229402019930943462534319453394436095'
+};
+
+describe('encodeBI/decodeBI using custom params', () => {
+
+	for (const id in map) {
+
+		const bi = map[id];
+
+		it(`should encode '${bi}' to '${id}'`, () => {
+			assert.equal(id, hashids.encodeBI(bi));
+		});
+
+		it(`should encode '${bi}' to '${id}' and decode back correctly`, () => {
+
+			const encodedId = hashids.encodeBI(bi);
+			const decodedBI = hashids.decodeBI(encodedId);
+
+			assert.deepEqual(bi, decodedBI);
+
+		});
+
+		it(`id length should be at least ${minLength}`, () => {
+			assert.isAtLeast(hashids.encodeBI(bi).length, minLength);
+		});
+
+	}
+
+});

--- a/tests/default-params-bi.js
+++ b/tests/default-params-bi.js
@@ -1,0 +1,39 @@
+
+import Hashids from '../lib/hashids';
+import { assert } from 'chai';
+
+const hashids = new Hashids();
+
+const map = {
+	'wpVL4j9g': '3735928559',
+	'kmP69lB3xv': '188900967593046',
+	'47JWg0kv4VU0G2KBO2': '12981155274522450858012398',
+	'y42LW46J9luq3Xq9XMly': '24912482966938930280208240657',
+	'm1rO8xBQNquXmLvmO65BUO9KQmj': '19938421193860583634706025513334057899',
+	'wBlnMA23NLIQDgw7XxErc2mlNyAjpw': '14966276559563682702364767401166784150254678',
+	'VwLAoD9BqlT7xn4ZnBXJFmGZ51ZqrBhqrymEyvYLIP199': '6170642089954522658081134434590064393685259496125924487557283855',
+	'nBrz1rYyV0C0XKNXxB54fWN0yNvVjlip7127Jo3ri0Pqw': '6582018229284824168619876730229402019930943462534319453394436095'
+};
+
+describe('encodeBI/decodeBI using default params', () => {
+
+	for (const id in map) {
+
+		const bi = map[id];
+
+		it(`should encode '${bi}' to '${id}'`, () => {
+			assert.equal(id, hashids.encodeBI(bi));
+		});
+
+		it(`should encode '${bi}' to '${id}' and decode back correctly`, () => {
+
+			const encodedId = hashids.encodeBI(bi);
+			const decodedBI = hashids.decodeBI(encodedId);
+
+			assert.deepEqual(bi, decodedBI);
+
+		});
+
+	}
+
+});


### PR DESCRIPTION
As a proposal it would be helpfull to have calls to handle bigint in case of handling Big Integer Ids from a DB.

I implemented initially using npm [big-integer](https://github.com/peterolson/BigInteger.js) library.

I also implemented as a complementary library on my repository [hashids-bigint](https://github.com/prodrigestivill/hashids-bigint).

This library is not yet published to npm, because I believe it would be better to have support in the same library.

Let me know what do you think, I undestand that adding an optional dependency might not be desirable.

Possible solutions:
- It can be implemented to support javascript [native bigint](https://tc39.github.io/proposal-bigint/) but this might be too new.
- It can be implemented as required dependency.