### PR TITLE
fix: use type error when needed

### DIFF
--- a/lib/hashids.ts
+++ b/lib/hashids.ts
@@ -12,17 +12,17 @@ export default class Hashids {
     seps = 'cfhistuCFHISTU',
   ) {
     if (typeof minLength !== 'number') {
-      throw new Error(
+      throw new TypeError(
         `Hashids: Provided 'minLength' has to be a number (is ${typeof minLength})`,
       )
     }
     if (typeof salt !== 'string') {
-      throw new Error(
+      throw new TypeError(
         `Hashids: Provided 'salt' has to be a string (is ${typeof salt})`,
       )
     }
     if (typeof alphabet !== 'string') {
-      throw new Error(
+      throw new TypeError(
         `Hashids: Provided alphabet has to be a string (is ${typeof alphabet})`,
       )
     }

--- a/tests/bad-input.test.ts
+++ b/tests/bad-input.test.ts
@@ -9,6 +9,12 @@ describe('bad input', () => {
     }).toThrow()
   })
 
+  test(`should throw an error when alphabet not a string`, () => {
+    expect(() => {
+      void new Hashids('', 0, 7)
+    }).toThrow(TypeError)
+  })
+
   test(`should not throw an error when alphabet has spaces`, () => {
     expect(() => {
       void new Hashids('', 0, 'a cdefghijklmnopqrstuvwxyz')


### PR DESCRIPTION
Hi @niieani,

Thanks for that awesome project 👍 

I think TypeError would suit better in case of type error 😄 

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypeError#Description)
>A `TypeError` is thrown when an operand or argument passed to a function is incompatible with the type expected by that operator or function.