### PR TITLE
fix: drop browser field with UMD

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   },
   "main": "esm/index.js",
   "module": "esm/index.js",
-  "browser": "dist/hashids.min",
   "exports": {
     ".": {
       "import": "./esm/index.js",


### PR DESCRIPTION
Browser field is not supposed to be used for distributing UMD bundles. It's a switch between node and browser environments.
All bundlers prefer browser field over module and main.

See here an example https://github.com/visgl/react-map-gl/blob/15ae86247b934cd0a43f0eba1cb109c74c3eee6b/package.json#L17-L25