### PR TITLE
fix: export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     },
     "./esm/": {
       "import": "./esm/"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "scripts": {
     "lint": "eslint lib/* tests/*",


### PR DESCRIPTION
fixes an error with rollup-plugin-svelte, but should be more generally useful for tools that want to introspect `package.json`:

```
rollup-plugin-svelte: The following packages did not export their `package.json` file so we could not check the `svelte` field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.
```