### PR TITLE
fix: reprioritize browser export

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,9 @@
   "module": "esm/index.js",
   "exports": {
     ".": {
+      "browser": "./dist/hashids.min.js",
       "import": "./esm/index.js",
-      "require": "./cjs/index.js",
-      "browser": "./dist/hashids.min.js"
+      "require": "./cjs/index.js"
     },
     "./cjs": {
       "require": "./cjs/index.js"


### PR DESCRIPTION
The `browser` field needs to be listed first otherwise one of `require` or `import` will match even with a browser target.

fixes #333