### PR TITLE
fix: remove yarn from the package to make the package smaller

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "bugs": {
     "url": "https://github.com/niieani/hashids.js/issues"
   },
+  "files": [
+    "cjs",
+    "esm",
+    "dist"
+  ],
   "main": "esm/index.js",
   "module": "esm/index.js",
   "exports": {


### PR DESCRIPTION
In v2.2 yarn was comitted locally and published on npm.
The package now is 3mb https://packagephobia.com/result?p=hashids

Better to ignore everything not related.