### PR TITLE
docs: added a note about importing the module in TypeScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,20 @@ Note: When using Node that supports [conditional exports](https://nodejs.org/api
 
 #### Use in **TypeScript**:
 
-Import or require based on the environment (see above).
+Import or require based on the environment (see above). If you want to use the CommonJS module syntax (`require`), you'll need to install the Node.js types from the `DefinitelyTyped` repository.
+
+```
+npm install @types/node
+```
+
+If you want to use the ESM syntax (`import`), you will need to include the following options in your `tsconfig.json`.
+
+```json
+{
+  "allowSyntheticDefaultImports": true,
+  "esModuleInterop": true
+}
+```
 
 If you get errors stating: `Cannot find name 'BigInt'`, add [`"esnext.bigint"`](https://github.com/microsoft/TypeScript/blob/master/src/lib/esnext.bigint.d.ts) or [`"esnext"`](https://github.com/microsoft/TypeScript/blob/master/src/lib/esnext.d.ts) to your `tsconfig.json` file, under `"lib"`:
 


### PR DESCRIPTION
Closes #210. 

I added some documentation to make sure that both cases are covered and I also created a repository to test things out in to make sure that it works. It is currently fixed at Node.js 12 and Typescript 3 because that's what the original issue was asking about. 

You can see the `import` syntax working on the [`import` branch](https://github.com/YashdalfTheGray/hashids-test/tree/import) and the `require` syntax working on the [`require` branch](https://github.com/YashdalfTheGray/hashids-test/tree/require). 