### PR TITLE
fix: add ".js" extension to type definition import

### DIFF
--- a/add-extension.sh
+++ b/add-extension.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
-declare file="esm/hashids.js"
+function addJsExtension() {
+  declare file="$1"
+  declare replacement="from './util.js'"
+  declare file_contents
+  file_contents=$(<$file)
+  echo "${file_contents//from \'.\/util\'/${replacement}}" >"$file"
+}
 
-declare file_contents
-file_contents=$(<$file)
-
-declare replacement="from './util.js'"
-
-echo "${file_contents//from \'.\/util\'/${replacement}}" >"$file"
+addJsExtension "esm/hashids.js"
+addJsExtension "esm/hashids.d.ts"

--- a/esm/hashids.d.ts
+++ b/esm/hashids.d.ts
@@ -1,4 +1,4 @@
-import type { NumberLike } from './util';
+import type { NumberLike } from './util.js';
 export default class Hashids {
     private minLength;
     private alphabet;


### PR DESCRIPTION
When using TypeScript together with esm we run into the following issue at compile time:

```sh
node_modules/hashids/esm/hashids.d.ts:1:33 - error TS2835: Relative import paths need explicit file extensions in EcmaScript imports when '--moduleResolution' is 'node16' or 'nodenext'. Did you mean './util.js'?

1 import type { NumberLike } from './util';
                                  ~~~~~~~~


Found 1 error in node_modules/hashids/esm/hashids.d.ts:1
```  

Issue seems to be that the ".js" extension is missing in the definition file as well as adding it fixes the issue.
